### PR TITLE
Added Resolution Presets!

### DIFF
--- a/EditorScreenshot.cs
+++ b/EditorScreenshot.cs
@@ -263,7 +263,7 @@ namespace Pumkin.EditorScreenshot
 
             // Add preset Vector2Ints for each Resolution Preset
             List<Vector2Int> presetResolutions = new List<Vector2Int>() {
-                new Vector2Int(1200, 900), // VRC Preview Thumbnail
+                new Vector2Int(1200, 900), // VRC Avatar and World Thumbnail
                 new Vector2Int(720, 480), // 480p SD
                 new Vector2Int(1280, 720), // 720p HD
                 new Vector2Int(1920, 1080), // 1080p FHD
@@ -275,7 +275,7 @@ namespace Pumkin.EditorScreenshot
 
             // Replace Labels on the UI to these Strings (MUST MATCH EXACT ORDER AS ABOVE!!)
             List<string> presetLabels = new List<string>() {
-                "VRC Preview Thumbnail",
+                "VRC Thumbnail",
                 "480p",
                 "720p",
                 "1080p",

--- a/EditorScreenshot.cs
+++ b/EditorScreenshot.cs
@@ -264,18 +264,24 @@ namespace Pumkin.EditorScreenshot
             // Add preset Vector2Ints for each Resolution Preset
             List<Vector2Int> presetResolutions = new List<Vector2Int>() {
                 new Vector2Int(1200, 900), // VRC Preview Thumbnail
-                new Vector2Int(1920, 1080), // 1080p HD
-                new Vector2Int(2560, 1440), // 1440p HD
+                new Vector2Int(720, 480), // 480p SD
+                new Vector2Int(1280, 720), // 720p HD
+                new Vector2Int(1920, 1080), // 1080p FHD
+                new Vector2Int(2560, 1440), // 1440p QHD
                 new Vector2Int(3840, 2160), // 4K UHD
+                new Vector2Int(7680, 4320), // 8K UHD
                 new Vector2Int(-1, -1) // This is a Custom Resolution
             };
 
             // Replace Labels on the UI to these Strings (MUST MATCH EXACT ORDER AS ABOVE!!)
             List<string> presetLabels = new List<string>() {
                 "VRC Preview Thumbnail",
-                "1080p HD",
-                "1440p WQHD",
-                "4K UHD",
+                "480p",
+                "720p",
+                "1080p",
+                "1440p",
+                "4K",
+                "8K",
                 "Custom"
             };
             

--- a/EditorScreenshot.cs
+++ b/EditorScreenshot.cs
@@ -3,7 +3,9 @@
 // Based on an ancient tool somewhere on the Asset Store called Instant Screenshot by Saad Khawaja.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using UnityEditor;
 using UnityEditor.UIElements;
 using UnityEditorInternal;
@@ -256,6 +258,68 @@ namespace Pumkin.EditorScreenshot
                 UpdateResolutionInfoLabel();
             });
             resHeightField.value = resolution.y;
+
+            // BEGIN Resolution Presets Dropdown
+
+            // Add preset Vector2Ints for each Resolution Preset
+            List<Vector2Int> presetResolutions = new List<Vector2Int>() {
+                new Vector2Int(1200, 900), // VRC Preview Thumbnail
+                new Vector2Int(1920, 1080), // 1080p HD
+                new Vector2Int(2560, 1440), // 1440p HD
+                new Vector2Int(3840, 2160), // 4K UHD
+                new Vector2Int(-1, -1) // This is a Custom Resolution
+            };
+
+            // Replace Labels on the UI to these Strings (MUST MATCH EXACT ORDER AS ABOVE!!)
+            List<string> presetLabels = new List<string>() {
+                "VRC Preview Thumbnail",
+                "1080p HD",
+                "1440p WQHD",
+                "4K UHD",
+                "Custom"
+            };
+            
+            // Create VisualElement for the Preset Dropdown
+            VisualElement resolutionContainer = tree.Q<VisualElement>("resolutionContainer");
+
+            // Create PopupField
+            PopupField<Vector2Int> resolutionDropdown = new PopupField<Vector2Int>("Presets", presetResolutions, 0,
+            formatListItemCallback: (Vector2Int res) => {
+                int index = presetResolutions.IndexOf(res);
+                return index >= 0 ? presetLabels[index] : "Custom";
+            },
+            formatSelectedValueCallback: (Vector2Int res) => {
+                int index = presetResolutions.IndexOf(res);
+                return index >= 0 ? presetLabels[index] : "Custom";
+            });
+            
+            // Add change listeners to the Integer Fields
+            resWidthField.RegisterValueChangedCallback(evt => {
+                if (!presetResolutions.Any(res => res.x == evt.newValue && res.y == resHeightField.value)) {
+                    resolutionDropdown.value = new Vector2Int(-1, -1); // Set to Custom
+                }
+            });
+            resHeightField.RegisterValueChangedCallback(evt => {
+                if (!presetResolutions.Any(res => res.y == evt.newValue && res.x == resWidthField.value)) {
+                    resolutionDropdown.value = new Vector2Int(-1, -1); // Set to Custom
+                }
+            });
+            
+            // Dropdown Change Event Handler
+            resolutionDropdown.RegisterValueChangedCallback(evt => {
+                if (evt.newValue.x == -1 && evt.newValue.y == -1) {
+                    return; // Don't update the Integer Fields if "Custom" is selected
+                }
+                resolution = evt.newValue;
+                resWidthField.value = resolution.x;
+                resHeightField.value = resolution.y;
+                UpdateResolutionInfoLabel();
+            });
+            
+            // Add Dropdown to the resolutionContainer
+            resolutionContainer.Add(resolutionDropdown);
+            
+            // END Resolution Presets Dropdown
 
             IntegerField multiplierInt = tree.Q<IntegerField>("multiplierInt");
             SliderInt multiplierSlider = tree.Q<SliderInt>("multiplierSlider");

--- a/EditorScreenshot.cs
+++ b/EditorScreenshot.cs
@@ -273,7 +273,7 @@ namespace Pumkin.EditorScreenshot
                 new Vector2Int(-1, -1) // This is a Custom Resolution
             };
 
-            // Replace Labels on the UI to these Strings (MUST MATCH EXACT ORDER AS ABOVE!!)
+            // Fix and replace UI Label Text from showing as Vector2Ints in the Presets Dropdown (MUST MATCH EXACT ORDER AS ABOVE!!)
             List<string> presetLabels = new List<string>() {
                 "VRC Thumbnail",
                 "480p",
@@ -285,10 +285,10 @@ namespace Pumkin.EditorScreenshot
                 "Custom"
             };
             
-            // Create VisualElement for the Preset Dropdown
+            // Create VisualElement for the Presets Dropdown
             VisualElement resolutionContainer = tree.Q<VisualElement>("resolutionContainer");
 
-            // Create PopupField
+            // Create Presets Dropdown
             PopupField<Vector2Int> resolutionDropdown = new PopupField<Vector2Int>("Presets", presetResolutions, 0,
             formatListItemCallback: (Vector2Int res) => {
                 int index = presetResolutions.IndexOf(res);
@@ -299,7 +299,7 @@ namespace Pumkin.EditorScreenshot
                 return index >= 0 ? presetLabels[index] : "Custom";
             });
             
-            // Add change listeners to the Integer Fields
+            // Add listeners to ensure "Custom" is auto-selected when Resolution is manually typed in
             resWidthField.RegisterValueChangedCallback(evt => {
                 if (!presetResolutions.Any(res => res.x == evt.newValue && res.y == resHeightField.value)) {
                     resolutionDropdown.value = new Vector2Int(-1, -1); // Set to Custom
@@ -311,7 +311,7 @@ namespace Pumkin.EditorScreenshot
                 }
             });
             
-            // Dropdown Change Event Handler
+            // Presets Dropdown Event Handler
             resolutionDropdown.RegisterValueChangedCallback(evt => {
                 if (evt.newValue.x == -1 && evt.newValue.y == -1) {
                     return; // Don't update the Integer Fields if "Custom" is selected


### PR DESCRIPTION
In this commit, I have added predetermined common Resolutions that can be applied to the Width and Height instantly from a dropdown menu in the Window! Say goodbye to manually typing your preferred resolution each time! This is something I think was missing from this Script and I think it will be extremely beneficial for everyone.

This code was tested in Unity 2022.3 and _should_ work without problems in Unity 2019.4.

_For more details on this code, please view the comments I left on the script. Feel free to delete my comments after you have read and understood them._

## Added
- Presets Dropdown containing predefined common resolutions that you can select from, including:
    - `VRC Thumbnail`: The standard image size for Avatar and World Thumbnails in VRChat and the SDK (1200 x 900).
    - `480p`: The infamous old VGA format (720 x 480).
    - `720p`: The first HD standard format (1280 x 720).
    - `1080p`: The global standard Full HD format (1920 x 1080).
    - `1440p`: Commonly misconceived as 2K, it's the Wide Quad HD format (2560 x 1440).
    - `4K`: The standard Ultra HD Format (3840 x 2160).
    - `8K`: The super Ultra HD Format (7680 x 4320).
- Added checks to change the Presets selection to `Custom` only if you begin to manually type in a custom value.